### PR TITLE
Use "${R_HOME}/bin/R" for fetching icudt

### DIFF
--- a/configure
+++ b/configure
@@ -4621,7 +4621,7 @@ if test $ICU_FOUND = 0; then
 
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether we can fetch icudt" >&5
 $as_echo_n "checking whether we can fetch icudt... " >&6; }
-   R --vanilla --slave -e "setwd(\"src/\"); \
+   "${R_HOME}/bin/R" --vanilla --slave -e "setwd(\"src/\"); \
                            source(\"../R/install.R\"); \
                            if (identical(FALSE,stri_download_icudt(\"${ICUDT_DIR}\"))) \
                                stop(\"Stopping on error\")"

--- a/configure.ac
+++ b/configure.ac
@@ -671,7 +671,7 @@ if test $ICU_FOUND = 0; then
    CPPFLAGS=$OLD_CPPFLAGS
 
    AC_MSG_CHECKING([whether we can fetch icudt])
-   R --vanilla --slave -e "setwd(\"src/\"); \
+   "${R_HOME}/bin/R" --vanilla --slave -e "setwd(\"src/\"); \
                            source(\"../R/install.R\"); \
                            if (identical(FALSE,stri_download_icudt(\"${ICUDT_DIR}\"))) \
                                stop(\"Stopping on error\")"


### PR DESCRIPTION
Otherwise installation depends on which R (if any) is on the
PATH. Noticed this because dir.exists() does not exist in R < 3.2.0, R
3.0.2 was on the PATH, and installation failed.