### PR TITLE
Test R version for R_forceSymbols(), workaround for conflicting FALSE (TRUE)

### DIFF
--- a/src/stri_external.h
+++ b/src/stri_external.h
@@ -64,6 +64,7 @@ using namespace icu;
 #define USE_RINTERNALS
 #define R_NO_REMAP
 #include <R.h>
+#include <Rversion.h>
 #include <Rinternals.h>
 #include <Rmath.h>
 #include <Rdefines.h>

--- a/src/stri_stringi.cpp
+++ b/src/stri_stringi.cpp
@@ -306,7 +306,9 @@ extern "C" void R_init_stringi(DllInfo* dll)
 
    R_registerRoutines(dll, NULL, cCallMethods, NULL, NULL);
    R_useDynamicSymbols(dll, FALSE);
+#if defined(R_VERSION) && R_VERSION >= R_Version(3, 0, 0)
    R_forceSymbols(dll, TRUE);
+#endif
 
    const R_CallMethodDef* methods = cCallMethods;
    while (methods->name) {

--- a/src/stri_stringi.cpp
+++ b/src/stri_stringi.cpp
@@ -305,9 +305,9 @@ extern "C" void R_init_stringi(DllInfo* dll)
       Rf_error("ICU init failed: %s", u_errorName(status));
 
    R_registerRoutines(dll, NULL, cCallMethods, NULL, NULL);
-   R_useDynamicSymbols(dll, FALSE);
+   R_useDynamicSymbols(dll, (Rboolean)FALSE);
 #if defined(R_VERSION) && R_VERSION >= R_Version(3, 0, 0)
-   R_forceSymbols(dll, TRUE);
+   R_forceSymbols(dll, (Rboolean)TRUE);
 #endif
 
    const R_CallMethodDef* methods = cCallMethods;


### PR DESCRIPTION
`R_forceSymbols()` is R >= 3.0.0. Using `FALSE` as it was gave the following error on R 2.15.2, gcc / g++ 4.8.4:

    stri_stringi.cpp:308:34: error: invalid conversion from ‘int’ to ‘Rboolean’ 
        R_useDynamicSymbols(dll, FALSE);

The file _`Rdefines.h`_ (message of commit 2e0fd0b has a thinko) currently has the following comment about the definitions for `TRUE` and `FALSE`:

    /* These conflict with definitions in R_ext/Boolean.h,
       but spatstat relies on them in a C file */
