### PR TITLE
switch phrases from informal to formal

### DIFF
--- a/R/compare.R
+++ b/R/compare.R
@@ -49,7 +49,7 @@
 #' locale-independent operations: for natural language text processing,
 #' in which the notion of canonical equivalence is more valid, this might
 #' not be exactly what you are looking for, see Examples.
-#' By the way, note that \pkg{stringi} always silently removes UTF-8
+#' Please note that \pkg{stringi} always silently removes UTF-8
 #' BOMs from input strings, so e.g. \code{stri_cmp_eq} does not take
 #' BOMs into account while comparing strings.
 #'

--- a/R/encoding.R
+++ b/R/encoding.R
@@ -90,7 +90,7 @@
 #' for representing Unicode character strings in \R. UTF-8 has ASCII as its
 #' subset (code points 1--127 represent the same characters in both of them).
 #' Code points larger than 127 are represented by multi-byte sequences
-#' (from 2 to 4 bytes: by the way, not all sequences of bytes are valid UTF-8,
+#' (from 2 to 4 bytes: Please note that not all sequences of bytes are valid UTF-8,
 #' cf. \code{\link{stri_enc_isutf8}}).
 #'
 #' Most of the computations in \pkg{stringi} are performed internally

--- a/R/search_match_4.R
+++ b/R/search_match_4.R
@@ -44,7 +44,7 @@
 #' If no pattern match is detected and \code{omit_no_match=FALSE},
 #' then \code{NA}s are included in the resulting matrix (matrices), see Examples.
 #'
-#' By the way, \pkg{ICU} regex engine currently does not support named capture groups.
+#' Please note: \pkg{ICU} regex engine currently does not support named capture groups.
 #'
 #' \code{stri_match}, \code{stri_match_all}, \code{stri_match_first},
 #' and \code{stri_match_last} are convenience functions.

--- a/devel/doc/compat_tab_conversion.Rhtml
+++ b/devel/doc/compat_tab_conversion.Rhtml
@@ -304,7 +304,7 @@ end.rcode-->
    <p>Depending on the version of the ICU library used,
    each encoding should be supported across all platforms.</p>
    
-   <p>By the way, <code><!--rinline "stri_enc_info()" --></code>
+   <p>Please note: <code><!--rinline "stri_enc_info()" --></code>
    returns detailed information of a given encoding specifier.</p>
 
 <!--begin.rcode

--- a/man/stri_compare.Rd
+++ b/man/stri_compare.Rd
@@ -69,7 +69,7 @@ to check whether there is any difference between them. These are
 locale-independent operations: for natural language text processing,
 in which the notion of canonical equivalence is more valid, this might
 not be exactly what you are looking for, see Examples.
-By the way, note that \pkg{stringi} always silently removes UTF-8
+Please note that \pkg{stringi} always silently removes UTF-8
 BOMs from input strings, so e.g. \code{stri_cmp_eq} does not take
 BOMs into account while comparing strings.
 

--- a/man/stri_match.Rd
+++ b/man/stri_match.Rd
@@ -74,7 +74,7 @@ Vectorized over \code{str} and \code{pattern}.
 If no pattern match is detected and \code{omit_no_match=FALSE},
 then \code{NA}s are included in the resulting matrix (matrices), see Examples.
 
-By the way, \pkg{ICU} regex engine currently does not support named capture groups.
+Please note: \pkg{ICU} regex engine currently does not support named capture groups.
 
 \code{stri_match}, \code{stri_match_all}, \code{stri_match_first},
 and \code{stri_match_last} are convenience functions.

--- a/man/stringi-encoding.Rd
+++ b/man/stringi-encoding.Rd
@@ -62,7 +62,7 @@ For portability reasons, the UTF-8 encoding is the most natural choice
 for representing Unicode character strings in \R. UTF-8 has ASCII as its
 subset (code points 1--127 represent the same characters in both of them).
 Code points larger than 127 are represented by multi-byte sequences
-(from 2 to 4 bytes: by the way, not all sequences of bytes are valid UTF-8,
+(from 2 to 4 bytes: Please note that not all sequences of bytes are valid UTF-8,
 cf. \code{\link{stri_enc_isutf8}}).
 
 Most of the computations in \pkg{stringi} are performed internally


### PR DESCRIPTION
I stumbled over the "by the way" in the help pages today, and thought it might sound better in a more formal way. Knowing that personal preference can play a large role here, I'm totally fine with this PR being closed and the informal variant remaining.

Cheers :-)