### PR TITLE
Remove redundant rules to fix arm64 build

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -50,10 +50,8 @@ $(SHLIB): $(OBJECTS) libicu_common.a libicu_i18n.a libicu_stubdata.a
 PKG_LIBS=-L. -licu_common -licu_i18n -licu_stubdata
 
 libicu_common.a: $(ICU_COMMON_OBJECTS)
-	$(AR) rcs -o libicu_common.a $(ICU_COMMON_OBJECTS)
 
 libicu_i18n.a: $(ICU_I18N_OBJECTS)
-	$(AR) rcs -o libicu_i18n.a $(ICU_I18N_OBJECTS)
 
 libicu_stubdata.a: $(ICU_STUBDATA_OBJECTS)
-	$(AR) rcs -o libicu_stubdata.a $(ICU_STUBDATA_OBJECTS)
+


### PR DESCRIPTION
This fixes https://github.com/gagolews/stringi/issues/497

The $(AR) command that is currently in Makevars.win does not work with llvm (needed on arm64 windows). However the fix is easy: these rules are actually redundant, because R's builtin Makefile already defines the proper rule for creating a static library from object files, here: https://github.com/r-devel/r-svn/blob/HEAD/src/gnuwin32/fixed/etc/Makeconf#L323-L326

So a simple solution is to simply remove this line. I confirmed that with this we can build stringi on arm64 on Windows.