### PR TITLE
Windows: fix linking order for R-4.5

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -43,7 +43,7 @@ all: $(SHLIB)
 
 $(SHLIB): $(OBJECTS) libicu_common.a libicu_i18n.a libicu_stubdata.a
 
-PKG_LIBS=-L. -licu_stubdata -licu_common -licu_i18n
+PKG_LIBS=-L. -licu_i18n -licu_common -licu_stubdata
 
 libicu_common.a: $(ICU_COMMON_OBJECTS)
 


### PR DESCRIPTION
Fixes #508. Still don't understand why this surfaces in R-4.5, maybe they changed something in the toolchain or defaults.
