### PR TITLE
Fix build on r-devel

### DIFF
--- a/src/uconfig_local.h.in
+++ b/src/uconfig_local.h.in
@@ -47,13 +47,6 @@
  // do not turn on!
 */
 
-#if defined(__GNUC__) && __GNUC__ >= 3
-#define NORET __attribute__((noreturn))
-#else
-#define NORET
-#endif
-extern "C" void NORET Rf_error(const char *, ...);
-
 #define UPRV_UNREACHABLE_EXIT (Rf_error("ICU internal error: UPRV_UNREACHABLE"))
 #define DOUBLE_CONVERSION_UNIMPLEMENTED() (Rf_error("ICU internal error: DOUBLE_CONVERSION_UNIMPLEMENTED"))
 #define DOUBLE_CONVERSION_UNREACHABLE()   (Rf_error("ICU internal error: DOUBLE_CONVERSION_UNREACHABLE"))


### PR DESCRIPTION
I was unable to install this package using the latest r-devel build on `rig`. The issue is that the header for `Rf_error` has changed. That part of the declaration used in this file. Removing the definition works, and everything installs.