### PR TITLE
Update NORET to match r-devel

### DIFF
--- a/src/uconfig_local.h.in
+++ b/src/uconfig_local.h.in
@@ -46,8 +46,9 @@
  //  #define U_DISABLE_RENAMING 1
  // do not turn on!
 */
-
-#if defined(__GNUC__) && __GNUC__ >= 3
+#ifdef  __cplusplus
+#define NORET [[noreturn]]
+#elif defined(__GNUC__) && __GNUC__ >= 3
 #define NORET __attribute__((noreturn))
 #else
 #define NORET


### PR DESCRIPTION
R-devel is now using the `[[noreturn]]` attribute for [`Rf_error` under C++](https://github.com/r-devel/r-svn/commit/ab379a315a9781872dbb000bbd3c91537015de26) and this is causing an error when compiling `stringi` under the new rtools45 ARM64 toolchain - since clang requires that the attributes match in subsequent declarations:

```
trying URL 'https://cloud.r-project.org/src/contrib/stringi_1.8.4.tar.gz'
Content type 'application/x-gzip' length 11917497 bytes (11.4 MB)
downloaded 11.4 MB

* installing *source* package 'stringi' ...
** this is package 'stringi' version '1.8.4'
** package 'stringi' successfully unpacked and MD5 sums checked
** using staged installation
ICU_FOUND=0
ICU_BUNDLE_VERSION=74
ICUDT_DIR=icu74/data
DISABLE_RESOLVE_LOCALE_NAME=0
** libs
using C++ compiler: 'clang version 19.1.7'

clang++ -std=gnu++17  -I"C:/PROGRA~1/R-AARC~1/R-devel/include" -DNDEBUG -I. -Iicu74/ -Iicu74/unicode -Iicu74/common -Iicu74/i18n -DUCONFIG_USE_LOCAL -DU_STATIC_IMPLEMENTATION -DU_COMMON_IMPLEMENTATION -DU_I18N_IMPLEMENTATION -DU_TOOLUTIL_IMPLEMENTATION -UDEBUG -DNDEBUG -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DU_USE_STRTOD_L=0  -w  -I"/aarch64-w64-mingw32.static.posix/include"      -O2 -Wall      -c stri_ICU_settings.cpp -o stri_ICU_settings.o
clang++ -std=gnu++17  -I"C:/PROGRA~1/R-AARC~1/R-devel/include" -DNDEBUG -I. -Iicu74/ -Iicu74/unicode -Iicu74/common -Iicu74/i18n -DUCONFIG_USE_LOCAL -DU_STATIC_IMPLEMENTATION -DU_COMMON_IMPLEMENTATION -DU_I18N_IMPLEMENTATION -DU_TOOLUTIL_IMPLEMENTATION -UDEBUG -DNDEBUG -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DU_USE_STRTOD_L=0  -w  -I"/aarch64-w64-mingw32.static.posix/include"      -O2 -Wall      -c stri_brkiter.cpp -o stri_brkiter.o
clang++ -std=gnu++17  -I"C:/PROGRA~1/R-AARC~1/R-devel/include" -DNDEBUG -I. -Iicu74/ -Iicu74/unicode -Iicu74/common -Iicu74/i18n -DUCONFIG_USE_LOCAL -DU_STATIC_IMPLEMENTATION -DU_COMMON_IMPLEMENTATION -DU_I18N_IMPLEMENTATION -DU_TOOLUTIL_IMPLEMENTATION -UDEBUG -DNDEBUG -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DU_USE_STRTOD_L=0  -w  -I"/aarch64-w64-mingw32.static.posix/include"      -O2 -Wall      -c stri_collator.cpp -o stri_collator.o
clang++ -std=gnu++17  -I"C:/PROGRA~1/R-AARC~1/R-devel/include" -DNDEBUG -I. -Iicu74/ -Iicu74/unicode -Iicu74/common -Iicu74/i18n -DUCONFIG_USE_LOCAL -DU_STATIC_IMPLEMENTATION -DU_COMMON_IMPLEMENTATION -DU_I18N_IMPLEMENTATION -DU_TOOLUTIL_IMPLEMENTATION -UDEBUG -DNDEBUG -DWINVER=0x0601 -D_WIN32_WINNT=0x0601 -DU_USE_STRTOD_L=0  -w  -I"/aarch64-w64-mingw32.static.posix/include"      -O2 -Wall      -c stri_common.cpp -o stri_common.o
In file included from stri_collator.cpp:33:
In file included from ./stri_stringi.h:36:
In file included from ./stri_external.h:68:
In file included from C:/PROGRA~1/R-AARC~1/R-devel/include/R.h:73:
C:/PROGRA~1/R-AARC~1/R-devel/include/R_ext/Error.h:58:3: error: 'noreturn' attribute does not appear on the first declaration
   58 | [[noreturn]] void Rf_error(const char *, ...) R_PRINTF_FORMAT(1, 2);
      |   ^
./uconfig_local.h:55:23: note: previous declaration is here
   55 | extern "C" void NORET Rf_error(const char *, ...);
```

This PR just updates the declaration to match that of R-devel