### PR TITLE
Preserve names where it makes sense

### DIFF
--- a/.devel/tinytest/test-preserve-names.R
+++ b/.devel/tinytest/test-preserve-names.R
@@ -7,3 +7,90 @@ x <- c(A = "3", B = "2", C = "1")
 expect_equal(stri_sort(x), c(C = "1", B = "2", A = "3"))
 expect_equal(stri_replace_all_fixed(x, "2", "0"), c(A = "3", B = "0", C = "1"))
 
+# Helper
+expect_names_equal <- function(obj, nm) expect_equal(names(obj), nm)
+
+# Basic fixtures
+xc <- c(A = "alpha", B = "beta", C = "gamma", D = NA_character_)
+
+# replace_na
+expect_equal(names(stri_replace_na(xc, replacement = "NA")), names(xc))
+
+# detect_* (logical vector) should preserve names
+expect_names_equal(stri_detect_fixed(xc, "a"), names(xc))
+expect_names_equal(stri_detect_regex(xc, "a"), names(xc))
+expect_names_equal(stri_detect_coll(xc, "a"), names(xc))
+expect_names_equal(stri_detect_charclass(xc, "\\p{L}"), names(xc))
+
+# count_* (integer vector) should preserve names
+expect_names_equal(stri_count_fixed(xc, "a"), names(xc))
+expect_names_equal(stri_count_regex(xc, "a"), names(xc))
+expect_names_equal(stri_count_coll(xc, "a"), names(xc))
+expect_names_equal(stri_count_charclass(xc, "\\p{L}"), names(xc))
+
+# startswith/endswith (logical vector) should preserve names
+expect_names_equal(stri_startswith_fixed(xc, "a"), names(xc))
+expect_names_equal(stri_endswith_fixed(xc, "a"), names(xc))
+expect_names_equal(stri_startswith_coll(xc, "a"), names(xc))
+expect_names_equal(stri_endswith_coll(xc, "a"), names(xc))
+expect_names_equal(stri_startswith_charclass(xc, "\\p{L}"), names(xc))
+expect_names_equal(stri_endswith_charclass(xc, "\\p{L}"), names(xc))
+
+# subset_* should preserve names of selected elements
+sub_fixed <- stri_subset_fixed(xc, "a")
+expect_equal(names(sub_fixed), names(xc)[stri_detect_fixed(xc, "a") %in% c(TRUE, NA)])
+sub_regex <- stri_subset_regex(xc, "a")
+expect_equal(names(sub_regex), names(xc)[stri_detect_regex(xc, "a") %in% c(TRUE, NA)])
+sub_coll <- stri_subset_coll(xc, "a")
+expect_equal(names(sub_coll), names(xc)[stri_detect_coll(xc, "a") %in% c(TRUE, NA)])
+sub_cc <- stri_subset_charclass(xc, "\\p{L}")
+expect_equal(names(sub_cc), names(xc)[stri_detect_charclass(xc, "\\p{L}") %in% c(TRUE, NA)])
+
+# replace_* result length unchanged; names preserved
+expect_names_equal(stri_replace_first_fixed(xc, "a", "A"), names(xc))
+expect_names_equal(stri_replace_last_fixed(xc, "a", "A"), names(xc))
+expect_names_equal(stri_replace_all_fixed(xc, "a", "A"), names(xc))
+
+expect_names_equal(stri_replace_first_regex(xc, "a", "A"), names(xc))
+expect_names_equal(stri_replace_last_regex(xc, "a", "A"), names(xc))
+expect_names_equal(stri_replace_all_regex(xc, "a", "A"), names(xc))
+
+expect_names_equal(stri_replace_first_coll(xc, "a", "A"), names(xc))
+expect_names_equal(stri_replace_last_coll(xc, "a", "A"), names(xc))
+expect_names_equal(stri_replace_all_coll(xc, "a", "A"), names(xc))
+
+expect_names_equal(stri_replace_first_charclass(xc, "\\p{L}", "X"), names(xc))
+expect_names_equal(stri_replace_last_charclass(xc, "\\p{L}", "X"), names(xc))
+expect_names_equal(stri_replace_all_charclass(xc, "\\p{L}", "X", merge = TRUE), names(xc))
+
+# extract first/last (character vector) should preserve names
+expect_names_equal(stri_extract_first_fixed(xc, "a"), names(xc))
+expect_names_equal(stri_extract_last_fixed(xc, "a"), names(xc))
+expect_names_equal(stri_extract_first_regex(xc, "a"), names(xc))
+expect_names_equal(stri_extract_last_regex(xc, "a"), names(xc))
+expect_names_equal(stri_extract_first_coll(xc, "a"), names(xc))
+expect_names_equal(stri_extract_last_coll(xc, "a"), names(xc))
+expect_names_equal(stri_extract_first_charclass(xc, "\\p{L}"), names(xc))
+expect_names_equal(stri_extract_last_charclass(xc, "\\p{L}"), names(xc))
+
+# extract_all_* (list) top-level names preserved
+expect_equal(names(stri_extract_all_fixed(xc, "a")), names(xc))
+expect_equal(names(stri_extract_all_regex(xc, "a", simplify = FALSE, omit_no_match = FALSE)), names(xc))
+expect_equal(names(stri_extract_all_coll(xc, "a")), names(xc))
+expect_equal(names(stri_extract_all_charclass(xc, "\\p{L}", merge = TRUE)), names(xc))
+
+# locate_all_* (list) top-level names preserved
+expect_equal(names(stri_locate_all_fixed(xc, "a")), names(xc))
+expect_equal(names(stri_locate_all_regex(xc, "a", omit_no_match = FALSE, capture_groups = FALSE, get_length = FALSE)), names(xc))
+expect_equal(names(stri_locate_all_coll(xc, "a")), names(xc))
+expect_equal(names(stri_locate_all_charclass(xc, "\\p{L}", merge = TRUE)), names(xc))
+
+# split_* (list) top-level names preserved
+expect_equal(names(stri_split_fixed(xc, "a")), names(xc))
+expect_equal(names(stri_split_regex(xc, "a")), names(xc))
+expect_equal(names(stri_split_coll(xc, "a")), names(xc))
+expect_equal(names(stri_split_charclass(xc, "\\p{L}")), names(xc))
+expect_equal(names(stri_split_lines(xc)), names(xc))
+
+# boundaries count preserves names
+expect_names_equal(stri_count_boundaries(xc), names(xc))

--- a/.devel/tinytest/test-preserve-names.R
+++ b/.devel/tinytest/test-preserve-names.R
@@ -1,0 +1,9 @@
+library("tinytest")
+library("stringi")
+
+# From https://github.com/tidyverse/stringr/issues/575
+
+x <- c(A = "3", B = "2", C = "1")
+expect_equal(stri_sort(x), c(C = "1", B = "2", A = "3"))
+expect_equal(stri_replace_all_fixed(x, "2", "0"), c(A = "3", B = "0", C = "1"))
+

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,9 @@
 # Changelog
 
+* [GENERAL] Names preservation: Many vectorized functions now preserve the
+  `names` attribute when sensible, e.g., when the output length matches a
+  named input (most commonly `str`). Subsetting propagates names of selected
+  elements.
 
 ## 1.8.7 (2025-03-27)
 

--- a/R/internal_prepare_arg.R
+++ b/R/internal_prepare_arg.R
@@ -91,8 +91,8 @@
 #'
 #' @section Preserving Object Attributes:
 #'
-#' Generally, all our functions drop input objects' attributes
-#' (e.g., \code{\link{names}}, \code{\link{dim}}, etc.).
+#' Generally, all our functions drop input objects' attributes except names
+#' (e.g., \code{\link{dim}}, etc.).
 #' This is due to deep vectorization as well as for efficiency reasons.
 #' If the preservation of attributes is needed,
 #' important attributes can be manually copied. Alternatively, the notation

--- a/src/stri_common.cpp
+++ b/src/stri_common.cpp
@@ -326,3 +326,34 @@ int stri__match_arg(const char* option, const char** set) {
     }
     return which;
 }
+
+
+/**
+ * Preserve names on ret from either src1 or src2 when lengths match
+ *
+ * @param ret output vector whose names may be set
+ * @param src1 first source (preferred)
+ * @param src2 second source (fallback)
+ * @param out_len expected length of ret
+ *
+ * @version 1.8.0-preserve-names (2025-09-01)
+ */
+void stri__preserve_names_from_sources(SEXP ret, SEXP src1, SEXP src2, R_len_t out_len)
+{
+    if (!ret) return;
+    if (out_len <= 0) return;
+    if (src1) {
+        SEXP n1 = Rf_getAttrib(src1, R_NamesSymbol);
+        if (!Rf_isNull(n1) && LENGTH(n1) == out_len) {
+            Rf_setAttrib(ret, R_NamesSymbol, n1);
+            return;
+        }
+    }
+    if (src2) {
+        SEXP n2 = Rf_getAttrib(src2, R_NamesSymbol);
+        if (!Rf_isNull(n2) && LENGTH(n2) == out_len) {
+            Rf_setAttrib(ret, R_NamesSymbol, n2);
+            return;
+        }
+    }
+}

--- a/src/stri_search_boundaries_count.cpp
+++ b/src/stri_search_boundaries_count.cpp
@@ -80,6 +80,9 @@ SEXP stri_count_boundaries(SEXP str, SEXP opts_brkiter)
         INTEGER(ret)[i] = cur_count;
     }
 
+    // Preserve names from `str`
+    stri__preserve_names_from_sources(ret, str, R_NilValue, str_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END({ /* no action */  })

--- a/src/stri_search_boundaries_extract.cpp
+++ b/src/stri_search_boundaries_extract.cpp
@@ -175,6 +175,9 @@ SEXP stri_extract_all_boundaries(SEXP str, SEXP simplify, SEXP omit_no_match, SE
         STRI__UNPROTECT(1);
     }
 
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, str_length);
+
     if (LOGICAL(simplify)[0] == NA_LOGICAL || LOGICAL(simplify)[0]) {
         SEXP robj_TRUE, robj_zero, robj_na_strings, robj_empty_strings;
         STRI__PROTECT(robj_TRUE = Rf_ScalarLogical(TRUE));

--- a/src/stri_search_boundaries_locate.cpp
+++ b/src/stri_search_boundaries_locate.cpp
@@ -251,6 +251,9 @@ SEXP stri_locate_all_boundaries(SEXP str, SEXP omit_no_match, SEXP opts_brkiter,
     }
 
     stri__locate_set_dimnames_list(ret, get_length1);
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, str_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END({ /* nothing special t.b.d. on error */ })

--- a/src/stri_search_boundaries_split.cpp
+++ b/src/stri_search_boundaries_split.cpp
@@ -139,6 +139,9 @@ SEXP stri_split_boundaries(SEXP str, SEXP n, SEXP tokens_only, SEXP simplify, SE
         STRI__UNPROTECT(1);
     }
 
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     if (LOGICAL(simplify)[0] == NA_LOGICAL || LOGICAL(simplify)[0]) {
         R_len_t n_min = 0;
         R_len_t n_length = LENGTH(n);

--- a/src/stri_search_class_count.cpp
+++ b/src/stri_search_class_count.cpp
@@ -99,6 +99,9 @@ SEXP stri_count_charclass(SEXP str, SEXP pattern)
         ret_tab[i] = count;
     }
 
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_class_detect.cpp
+++ b/src/stri_search_class_detect.cpp
@@ -116,6 +116,9 @@ SEXP stri_detect_charclass(SEXP str, SEXP pattern,
         if (max_count_1 > 0 && ret_tab[i]) --max_count_1;
     }
 
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_class_extract.cpp
+++ b/src/stri_search_class_extract.cpp
@@ -118,6 +118,9 @@ SEXP stri__extract_firstlast_charclass(SEXP str, SEXP pattern, bool first)
         }
     }
 
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)
@@ -257,6 +260,9 @@ SEXP stri_extract_all_charclass(SEXP str, SEXP pattern, SEXP merge, SEXP simplif
                                              :robj_empty_strings,
                                              robj_zero));
     }
+
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
 
     STRI__UNPROTECT_ALL
     return ret;

--- a/src/stri_search_class_locate.cpp
+++ b/src/stri_search_class_locate.cpp
@@ -253,6 +253,9 @@ SEXP stri_locate_all_charclass(SEXP str, SEXP pattern, SEXP merge, SEXP omit_no_
     }
 
     stri__locate_set_dimnames_list(ret, get_length1);
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_class_replace.cpp
+++ b/src/stri_search_class_replace.cpp
@@ -138,6 +138,9 @@ SEXP stri__replace_all_charclass_yes_vectorize_all(SEXP str, SEXP pattern, SEXP 
         SET_STRING_ELT(ret, i, Rf_mkCharLenCE(buf.data(), buf_used, CE_UTF8));
     }
 
+    // Preserve names from `str` when not recycled
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)
@@ -370,6 +373,9 @@ SEXP stri__replace_firstlast_charclass(SEXP str, SEXP pattern, SEXP replacement,
         memcpy(buf.data()+jlast+replacement_cur_n, str_cur_s+j, (size_t)str_cur_n-j);
         SET_STRING_ELT(ret, i, Rf_mkCharLenCE(buf.data(), buf_need, CE_UTF8));
     }
+
+    // Preserve names from `str` when not recycled
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
 
     STRI__UNPROTECT_ALL
     return ret;

--- a/src/stri_search_class_split.cpp
+++ b/src/stri_search_class_split.cpp
@@ -179,6 +179,9 @@ SEXP stri_split_charclass(SEXP str, SEXP pattern, SEXP n,
         STRI__UNPROTECT(1)
     }
 
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     if (LOGICAL(simplify)[0] == NA_LOGICAL || LOGICAL(simplify)[0]) {
         R_len_t n_min = 0;
         R_len_t n_length = LENGTH(n);

--- a/src/stri_search_class_startsendswith.cpp
+++ b/src/stri_search_class_startsendswith.cpp
@@ -106,6 +106,9 @@ SEXP stri_startswith_charclass(SEXP str, SEXP pattern, SEXP from, SEXP negate)
         }
     }
 
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END( ;/* do nothing special on error */ )
@@ -181,6 +184,9 @@ SEXP stri_endswith_charclass(SEXP str, SEXP pattern, SEXP to, SEXP negate)
                 ret_tab[i] = !ret_tab[i];
         }
     }
+
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
 
     STRI__UNPROTECT_ALL
     return ret;

--- a/src/stri_search_class_subset.cpp
+++ b/src/stri_search_class_subset.cpp
@@ -121,6 +121,20 @@ SEXP stri_subset_charclass(SEXP str, SEXP pattern, SEXP omit_na, SEXP negate)
 
     SEXP ret;
     STRI__PROTECT(ret = stri__subset_by_logical(str_cont, which, result_counter));
+
+    // Preserve names from `str` where elements are kept (TRUE or NA)
+    SEXP in_names = Rf_getAttrib(str, R_NamesSymbol);
+    if (!Rf_isNull(in_names) && LENGTH(in_names) == str_cont.get_n()) {
+        SEXP out_names;
+        STRI__PROTECT(out_names = Rf_allocVector(STRSXP, result_counter));
+        for (R_len_t j=0, i=0; i<result_counter; ++j) {
+            if (which[j] != FALSE) {
+                SET_STRING_ELT(out_names, i++, STRING_ELT(in_names, j));
+            }
+        }
+        Rf_setAttrib(ret, R_NamesSymbol, out_names);
+        STRI__UNPROTECT(1); // out_names
+    }
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_coll_count.cpp
+++ b/src/stri_search_coll_count.cpp
@@ -100,6 +100,9 @@ SEXP stri_count_coll(SEXP str, SEXP pattern, SEXP opts_collator)
         ucol_close(collator);
         collator=NULL;
     }
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(

--- a/src/stri_search_coll_detect.cpp
+++ b/src/stri_search_coll_detect.cpp
@@ -122,6 +122,9 @@ SEXP stri_detect_coll(SEXP str, SEXP pattern, SEXP negate,
         ucol_close(collator);
         collator=NULL;
     }
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(

--- a/src/stri_search_coll_extract.cpp
+++ b/src/stri_search_coll_extract.cpp
@@ -108,6 +108,9 @@ SEXP stri__extract_firstlast_coll(SEXP str, SEXP pattern, SEXP opts_collator, bo
         ucol_close(collator);
         collator=NULL;
     }
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(
@@ -258,6 +261,9 @@ SEXP stri_extract_all_coll(SEXP str, SEXP pattern, SEXP simplify, SEXP omit_no_m
                                              :robj_empty_strings,
                                              robj_zero));
     }
+
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
 
     STRI__UNPROTECT_ALL
     return ret;

--- a/src/stri_search_coll_locate.cpp
+++ b/src/stri_search_coll_locate.cpp
@@ -305,6 +305,9 @@ SEXP stri_locate_all_coll(SEXP str, SEXP pattern, SEXP omit_no_match, SEXP opts_
         ucol_close(collator);
         collator=NULL;
     }
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(

--- a/src/stri_search_coll_replace.cpp
+++ b/src/stri_search_coll_replace.cpp
@@ -152,8 +152,11 @@ SEXP stri__replace_allfirstlast_coll(SEXP str, SEXP pattern, SEXP replacement, S
         ucol_close(collator);
         collator=NULL;
     }
+    // Convert and preserve names from `str` when not recycled
+    SEXP ret = str_cont.toR();
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
     STRI__UNPROTECT_ALL
-    return str_cont.toR();
+    return ret;
     STRI__ERROR_HANDLER_END(
         if (collator) ucol_close(collator);
     )

--- a/src/stri_search_coll_split.cpp
+++ b/src/stri_search_coll_split.cpp
@@ -188,6 +188,9 @@ SEXP stri_split_coll(SEXP str, SEXP pattern, SEXP n, SEXP omit_empty,
         collator=NULL;
     }
 
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     if (LOGICAL(simplify)[0] == NA_LOGICAL || LOGICAL(simplify)[0]) {
         R_len_t n_min = 0;
         R_len_t n_length = LENGTH(n);

--- a/src/stri_search_coll_startsendswith.cpp
+++ b/src/stri_search_coll_startsendswith.cpp
@@ -122,6 +122,9 @@ SEXP stri_startswith_coll(SEXP str, SEXP pattern, SEXP from, SEXP negate, SEXP o
         ucol_close(collator);
         collator=NULL;
     }
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(
@@ -217,6 +220,9 @@ SEXP stri_endswith_coll(SEXP str, SEXP pattern, SEXP to, SEXP negate, SEXP opts_
         ucol_close(collator);
         collator=NULL;
     }
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(

--- a/src/stri_search_coll_subset.cpp
+++ b/src/stri_search_coll_subset.cpp
@@ -126,6 +126,20 @@ SEXP stri_subset_coll(SEXP str, SEXP pattern, SEXP omit_na, SEXP negate, SEXP op
     }
     SEXP ret;
     STRI__PROTECT(ret = stri__subset_by_logical(str_cont, which, result_counter));
+
+    // Preserve names from `str` where elements are kept (TRUE or NA)
+    SEXP in_names = Rf_getAttrib(str, R_NamesSymbol);
+    if (!Rf_isNull(in_names) && LENGTH(in_names) == str_cont.get_n()) {
+        SEXP out_names;
+        STRI__PROTECT(out_names = Rf_allocVector(STRSXP, result_counter));
+        for (R_len_t j=0, i=0; i<result_counter; ++j) {
+            if (which[j] != FALSE) {
+                SET_STRING_ELT(out_names, i++, STRING_ELT(in_names, j));
+            }
+        }
+        Rf_setAttrib(ret, R_NamesSymbol, out_names);
+        STRI__UNPROTECT(1); // out_names
+    }
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(

--- a/src/stri_search_fixed_count.cpp
+++ b/src/stri_search_fixed_count.cpp
@@ -98,6 +98,9 @@ SEXP stri_count_fixed(SEXP str, SEXP pattern, SEXP opts_fixed)
         ret_tab[i] = found;
     }
 
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END( ;/* do nothing special on error */ )

--- a/src/stri_search_fixed_detect.cpp
+++ b/src/stri_search_fixed_detect.cpp
@@ -113,6 +113,9 @@ SEXP stri_detect_fixed(SEXP str, SEXP pattern, SEXP negate,
         if (max_count_1 > 0 && ret_tab[i]) --max_count_1;
     }
 
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END( ;/* do nothing special on error */ )

--- a/src/stri_search_fixed_extract.cpp
+++ b/src/stri_search_fixed_extract.cpp
@@ -96,6 +96,9 @@ SEXP stri__extract_firstlast_fixed(SEXP str, SEXP pattern, SEXP opts_fixed, bool
         SET_STRING_ELT(ret, i, Rf_mkCharLenCE(str_cont.get(i).c_str()+start, len, CE_UTF8));
     }
 
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END({ /* no-op */ })
@@ -226,6 +229,9 @@ SEXP stri_extract_all_fixed(SEXP str, SEXP pattern, SEXP simplify, SEXP omit_no_
                                              :robj_empty_strings,
                                              robj_zero));
     }
+
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
 
     STRI__UNPROTECT_ALL
     return ret;

--- a/src/stri_search_fixed_locate.cpp
+++ b/src/stri_search_fixed_locate.cpp
@@ -293,6 +293,9 @@ SEXP stri_locate_all_fixed(SEXP str, SEXP pattern, SEXP omit_no_match, SEXP opts
     }
 
     stri__locate_set_dimnames_list(ret, get_length1);
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END( ;/* do nothing special on error */ )

--- a/src/stri_search_fixed_replace.cpp
+++ b/src/stri_search_fixed_replace.cpp
@@ -149,6 +149,9 @@ SEXP stri__replace_allfirstlast_fixed(SEXP str, SEXP pattern, SEXP replacement, 
         SET_STRING_ELT(ret, i, Rf_mkCharLenCE(buf.data(), buf_used, CE_UTF8));
     }
 
+    // Preserve names from `str` when not recycled
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_fixed_split.cpp
+++ b/src/stri_search_fixed_split.cpp
@@ -186,6 +186,9 @@ SEXP stri_split_fixed(SEXP str, SEXP pattern, SEXP n,
         STRI__UNPROTECT(1);
     }
 
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     if (LOGICAL(simplify)[0] == NA_LOGICAL || LOGICAL(simplify)[0]) {
         R_len_t n_min = 0;
         R_len_t n_length = LENGTH(n);

--- a/src/stri_search_fixed_startsendswith.cpp
+++ b/src/stri_search_fixed_startsendswith.cpp
@@ -108,6 +108,9 @@ SEXP stri_startswith_fixed(SEXP str, SEXP pattern, SEXP from, SEXP negate, SEXP 
             ret_tab[i] = !ret_tab[i];
     }
 
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END( ;/* do nothing special on error */ )
@@ -183,6 +186,9 @@ SEXP stri_endswith_fixed(SEXP str, SEXP pattern, SEXP to, SEXP negate, SEXP opts
         if (negate_1)
             ret_tab[i] = !ret_tab[i];
     }
+
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
 
     STRI__UNPROTECT_ALL
     return ret;

--- a/src/stri_search_fixed_subset.cpp
+++ b/src/stri_search_fixed_subset.cpp
@@ -118,6 +118,20 @@ SEXP stri_subset_fixed(SEXP str, SEXP pattern, SEXP omit_na, SEXP negate, SEXP o
 
     SEXP ret;
     STRI__PROTECT(ret = stri__subset_by_logical(str_cont, which, result_counter));
+
+    // Preserve names from `str` where elements are kept (TRUE or NA)
+    SEXP in_names = Rf_getAttrib(str, R_NamesSymbol);
+    if (!Rf_isNull(in_names) && LENGTH(in_names) == str_cont.get_n()) {
+        SEXP out_names;
+        STRI__PROTECT(out_names = Rf_allocVector(STRSXP, result_counter));
+        for (R_len_t j=0, i=0; i<result_counter; ++j) {
+            if (which[j] != FALSE) {
+                SET_STRING_ELT(out_names, i++, STRING_ELT(in_names, j));
+            }
+        }
+        Rf_setAttrib(ret, R_NamesSymbol, out_names);
+        STRI__UNPROTECT(1); // out_names
+    }
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END( ;/* do nothing special on error */ )
@@ -207,4 +221,3 @@ SEXP stri_subset_fixed_replacement(SEXP str, SEXP pattern, SEXP negate, SEXP opt
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)
 }
-

--- a/src/stri_search_other_split.cpp
+++ b/src/stri_search_other_split.cpp
@@ -276,6 +276,9 @@ SEXP stri_split_lines(SEXP str, SEXP omit_empty)
         STRI__UNPROTECT(1);
     }
 
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_regex_count.cpp
+++ b/src/stri_search_regex_count.cpp
@@ -102,6 +102,9 @@ SEXP stri_count_regex(SEXP str, SEXP pattern, SEXP opts_regex)
         ret_tab[i] = count;
     }
 
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_regex_detect.cpp
+++ b/src/stri_search_regex_detect.cpp
@@ -125,6 +125,9 @@ SEXP stri_detect_regex(SEXP str, SEXP pattern, SEXP negate,
 //      utext_close(str_text);
     }
 
+    // Preserve names: prefer names of the argument that determines length
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_regex_extract.cpp
+++ b/src/stri_search_regex_extract.cpp
@@ -122,6 +122,9 @@ SEXP stri__extract_firstlast_regex(SEXP str, SEXP pattern, SEXP opts_regex, bool
         utext_close(str_text);
         str_text = NULL;
     }
+    // Preserve names from a sensible source
+    stri__preserve_names_from_sources(ret, str, pattern, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(if (str_text) utext_close(str_text);)
@@ -255,6 +258,9 @@ SEXP stri_extract_all_regex(SEXP str, SEXP pattern, SEXP simplify, SEXP omit_no_
         utext_close(str_text);
         str_text = NULL;
     }
+
+    // Preserve names for list form (may be overwritten if simplified to matrix)
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
 
     if (LOGICAL(simplify)[0] == NA_LOGICAL || LOGICAL(simplify)[0]) {
         SEXP robj_TRUE, robj_zero, robj_na_strings, robj_empty_strings;

--- a/src/stri_search_regex_locate.cpp
+++ b/src/stri_search_regex_locate.cpp
@@ -264,6 +264,9 @@ SEXP stri_locate_all_regex(SEXP str, SEXP pattern, SEXP omit_no_match, SEXP opts
     }
 
     stri__locate_set_dimnames_list(ret, get_length1);  // all matrices get from&to colnames
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_regex_replace.cpp
+++ b/src/stri_search_regex_replace.cpp
@@ -142,6 +142,9 @@ SEXP stri__replace_allfirstlast_regex(SEXP str, SEXP pattern, SEXP replacement, 
         SET_STRING_ELT(ret, i, str_cont.toR(i));
     }
 
+    // Preserve names from `str` when not recycled
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_search_regex_split.cpp
+++ b/src/stri_search_regex_split.cpp
@@ -200,6 +200,9 @@ SEXP stri_split_regex(SEXP str, SEXP pattern, SEXP n, SEXP omit_empty,
         str_text = NULL;
     }
 
+    // Preserve names for list form
+    stri__preserve_names_from_sources(ret, str, R_NilValue, vectorize_length);
+
     if (LOGICAL(simplify)[0] == NA_LOGICAL || LOGICAL(simplify)[0]) {
         R_len_t n_min = 0;
         R_len_t n_length = LENGTH(n);

--- a/src/stri_search_regex_subset.cpp
+++ b/src/stri_search_regex_subset.cpp
@@ -120,6 +120,20 @@ SEXP stri_subset_regex(SEXP str, SEXP pattern, SEXP omit_na, SEXP negate, SEXP o
 
     SEXP ret;
     STRI__PROTECT(ret = stri__subset_by_logical(str_cont, which, result_counter));
+
+    // Preserve names from `str` where elements are kept (TRUE or NA)
+    SEXP in_names = Rf_getAttrib(str, R_NamesSymbol);
+    if (!Rf_isNull(in_names) && LENGTH(in_names) == str_cont.get_n()) {
+        SEXP out_names;
+        STRI__PROTECT(out_names = Rf_allocVector(STRSXP, result_counter));
+        for (R_len_t j=0, i=0; i<result_counter; ++j) {
+            if (which[j] != FALSE) {
+                SET_STRING_ELT(out_names, i++, STRING_ELT(in_names, j));
+            }
+        }
+        Rf_setAttrib(ret, R_NamesSymbol, out_names);
+        STRI__UNPROTECT(1); // out_names
+    }
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)

--- a/src/stri_sort.cpp
+++ b/src/stri_sort.cpp
@@ -188,6 +188,26 @@ SEXP stri_order_rank_or_sort(SEXP str, SEXP decreasing, SEXP na_last,
             for (std::deque<int>::iterator it=NA_pos.begin(); it!=NA_pos.end(); ++it, ++j)
                 SET_STRING_ELT(ret, j, NA_STRING);
         }
+
+        // Preserve and reorder names alongside values when available
+        SEXP in_names = Rf_getAttrib(str, R_NamesSymbol);
+        if (!Rf_isNull(in_names) && LENGTH(in_names) == LENGTH(str)) {
+            SEXP out_names;
+            STRI__PROTECT(out_names = Rf_allocVector(STRSXP, k+NA_pos.size()));
+            j = 0;
+            if (na_last_int != NA_LOGICAL && !na_last_int) {
+                for (std::deque<int>::iterator it=NA_pos.begin(); it!=NA_pos.end(); ++it, ++j)
+                    SET_STRING_ELT(out_names, j, STRING_ELT(in_names, *it));
+            }
+            for (std::vector<int>::iterator it=order.begin(); it!=order.end(); ++it, ++j)
+                SET_STRING_ELT(out_names, j, STRING_ELT(in_names, *it));
+            if (na_last_int != NA_LOGICAL && na_last_int) {
+                for (std::deque<int>::iterator it=NA_pos.begin(); it!=NA_pos.end(); ++it, ++j)
+                    SET_STRING_ELT(out_names, j, STRING_ELT(in_names, *it));
+            }
+            Rf_setAttrib(ret, R_NamesSymbol, out_names);
+            STRI__UNPROTECT(1); // out_names
+        }
     }
     else if (_type == STRI_SORTRANKORDER_ORDER) {
         STRI__PROTECT(ret = Rf_allocVector(INTSXP, k+NA_pos.size()));

--- a/src/stri_stringi.h
+++ b/src/stri_stringi.h
@@ -53,6 +53,7 @@ SEXP    stri__emptyList();
 SEXP    stri__matrix_NA_INTEGER(R_len_t nrow, R_len_t ncol, int filler=NA_INTEGER);  // TODO: other ones can be generalised too
 SEXP    stri__matrix_NA_STRING(R_len_t nrow, R_len_t ncol);
 int     stri__match_arg(const char* option, const char** set);
+void    stri__preserve_names_from_sources(SEXP ret, SEXP src1, SEXP src2, R_len_t out_len);
 
 // collator.cpp:
 struct UCollator;

--- a/src/stri_utils.cpp
+++ b/src/stri_utils.cpp
@@ -144,9 +144,11 @@ SEXP stri_replace_na(SEXP str, SEXP replacement) {
             SET_STRING_ELT(ret, i, na);
     }
 
+    // Preserve names from `str` when lengths match
+    stri__preserve_names_from_sources(ret, str, R_NilValue, str_len);
+
     STRI__UNPROTECT_ALL
     return ret;
     STRI__ERROR_HANDLER_END(;/* nothing special to be done on error */)
 }
-
 


### PR DESCRIPTION
Currently, `stringi` does not preserve names in character vectors, unlike base `sort`, `grep` and perhaps other functions.
This has surprised a few users of `stringr` (a thin wrapper around `stringi`) in tidyverse/stringr#575.

Examples:

``` r
x <- c(C = "3", B = "2", A = "1")
stringi::stri_sort(x)
#> [1] "1" "2" "3"
base::sort(x)
#>   A   B   C 
#> "1" "2" "3"
stringi::stri_subset_fixed(x, "2")
#> [1] "2"
base::grep("2", x, value = TRUE)
#>   B 
#> "2"
```

<sup>Created on 2025-09-01 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

It is a current [principle](https://stringi.gagolewski.com/weave/design_principles.html#further-deviations-from-base-r) of `stringi` to not preserve attributes, including names. There is, however, an open but ancient `stringi` issue on [Which functions should preserve objects' attributes?](https://github.com/gagolews/stringi/issues/59) The last post there is Hadley Wickham arguing for the preservation of names.

I propose to modify the principle to "preserve names where it makes sense".

This pull request passes all existing tests and adds new tests for the added functionality. R CMD check and devtools::check() report no new notes or warnings compared to current master.

The implementation was done by ChatGPT-5 running in the Codex extension to VSCode, as described in the commit message. I have reviewed the changes, which seem sensible and concise to me. Please let me know what you think.